### PR TITLE
Support empty OVER() clause in Window Specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added support for empty WINDOWS specificiations [#1293](https://github.com/sqlfluff/sqlfluff/pull/1293)
 ### Changed
 - Fix typo in the in the wild page [#1285](https://github.com/sqlfluff/sqlfluff/pull/1285)
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -845,7 +845,7 @@ class OverClauseSegment(BaseSegment):
         OneOf(
             Ref("SingleIdentifierGrammar"),  # Window name
             Bracketed(
-                Ref("WindowSpecificationSegment"),
+                Ref("WindowSpecificationSegment", optional=True),
             ),
         ),
     )
@@ -853,7 +853,7 @@ class OverClauseSegment(BaseSegment):
 
 @ansi_dialect.segment()
 class WindowSpecificationSegment(BaseSegment):
-    """Window specification, e.g. OVER() or named window."""
+    """Window specification within OVER(...)."""
 
     type = "window_specification"
     match_grammar = Sequence(

--- a/test/fixtures/parser/ansi/select_named_window_with_parentheses.sql
+++ b/test/fixtures/parser/ansi/select_named_window_with_parentheses.sql
@@ -1,5 +1,6 @@
 SELECT
-    NTH_VALUE(bar, 1) OVER(w1) AS baz
+    NTH_VALUE(bar, 1) OVER(w1) AS baz,
+    NTH_VALUE(bar, 1) OVER() AS foo
 FROM t
 WINDOW w1 AS (
     PARTITION BY

--- a/test/fixtures/parser/ansi/select_named_window_with_parentheses.yml
+++ b/test/fixtures/parser/ansi/select_named_window_with_parentheses.yml
@@ -2,8 +2,8 @@ file:
   statement:
     select_statement:
       select_clause:
-        keyword: SELECT
-        select_clause_element:
+      - keyword: SELECT
+      - select_clause_element:
           function:
             function_name:
               function_name_identifier: NTH_VALUE
@@ -26,6 +26,28 @@ file:
           alias_expression:
             keyword: AS
             identifier: baz
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: NTH_VALUE
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: bar
+            - comma: ','
+            - expression:
+                literal: '1'
+            - end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: foo
       from_clause:
         keyword: FROM
         from_expression:


### PR DESCRIPTION
---
name: Bug Fix/Demonstration
about: This fixes or demonstrates a bug in SQLFluff
labels: bug, documentation
---

-- Firstly, thanks for fixing a bug! Secondly, please make sure your PR includes a test case demonstrating that the bug is fixed. Test cases should be as minimal as possible to show it's fixed but also be representative of the case the original reporter of the bug posted. If this PR is just a failing test case, please file it as a `draft` PR or use pytest `xfail` to mark the case as expected to fail. --

### Bug fix checklist
- [ ] I have identified the root cause of the bug.
- I have fixed:
  - [ ] All cases affected by the bug.
  - [ ] Some cases affected by the bug, but others still remain.
  - [ ] No cases, this PR just adds a failing test case.
- [ ] This PR includes test cases to demonstrate the fix. Specifically:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/parser`.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [ ] This PR updates the [CHANGELOG.md](https://github.com/sqlfluff/sqlfluff/blob/master/CHANGELOG.md).

### What was the root cause of this bug?
...

### Are there any other side effects of this fix?
...

### How comprehensive is the test coverage of this fix?
...
